### PR TITLE
Some Meson housekeeping

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,10 @@
 project('allocator', 'd',
-    meson_version: '>=0.40',
+    meson_version: '>=0.44',
     license: 'BSL-1.0',
     version: '2.77.0'
 )
 
 project_soversion = '0'
-project_version   = meson.project_version()
 
 pkgc = import('pkgconfig')
 
@@ -47,14 +46,14 @@ allocator_lib = library('allocator',
         [allocator_src],
         include_directories: [src_dir],
         install: true,
-        version: project_version,
+        version: meson.project_version(),
         soversion: project_soversion
 )
 
 pkgc.generate(name: 'allocator',
               libraries: [allocator_lib],
               subdirs: 'd/allocator',
-              version: project_version,
+              version: meson.project_version(),
               description: 'Extracted std.experimental.allocator for usage via DUB.'
 )
 
@@ -70,7 +69,7 @@ allocator_dep = declare_dependency(
 allocator_test_exe = executable('test_allocator',
     [allocator_src],
     include_directories: [src_dir],
-    d_args: meson.get_compiler('d').unittest_args(),
+    d_unittest: true,
     link_args: '-main'
 )
 test('test_allocator', allocator_test_exe)

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('allocator', 'd',
     meson_version: '>=0.40',
-    license: 'MIT',
+    license: 'BSL-1.0',
     version: '2.77.0'
 )
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('allocator', 'd',
+project('stdx-allocator', 'd',
     meson_version: '>=0.44',
     license: 'BSL-1.0',
     version: '2.77.0'
@@ -42,7 +42,7 @@ src_dir = include_directories('source/')
 #
 # Targets
 #
-allocator_lib = library('allocator',
+allocator_lib = library('stdx-allocator',
         [allocator_src],
         include_directories: [src_dir],
         install: true,
@@ -50,7 +50,7 @@ allocator_lib = library('allocator',
         soversion: project_soversion
 )
 
-pkgc.generate(name: 'allocator',
+pkgc.generate(name: 'stdx-allocator',
               libraries: [allocator_lib],
               subdirs: 'd/allocator',
               version: meson.project_version(),


### PR DESCRIPTION
Besides some normal housekeeping stuff, this patch also renames the project and its library from "allocator" to "stdx-allocator".
Having a very generic name like allocator will make it really difficult to ship the library in Linux distributions, and while stdx-allocator is also pretty generic, I assume that name will pass through much easier.

This rename should not cause any problems for projects using this downstream, as the dependency variable is still named "allocator_dep" (and can remain that way). Therefore, all projects depending on this should just pick up the new library name without further changes.