### PR TITLE
meson: Fix pkg-config include directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ allocator_lib = library('stdx-allocator',
 
 pkgc.generate(name: 'stdx-allocator',
               libraries: [allocator_lib],
-              subdirs: 'd/stdx',
+              subdirs: 'd/stdx-allocator',
               version: meson.project_version(),
               description: 'High-level interface for allocators for D, extracted from Phobos.'
 )
@@ -77,4 +77,4 @@ test('test_allocator', allocator_test_exe)
 #
 # Install
 #
-install_subdir('source/stdx/', install_dir: 'include/d/stdx/')
+install_subdir('source/stdx/', install_dir: 'include/d/stdx-allocator/')

--- a/meson.build
+++ b/meson.build
@@ -54,7 +54,7 @@ pkgc.generate(name: 'stdx-allocator',
               libraries: [allocator_lib],
               subdirs: 'd/stdx',
               version: meson.project_version(),
-              description: 'Extracted std.experimental.allocator for usage via DUB.'
+              description: 'High-level interface for allocators for D, extracted from Phobos.'
 )
 
 # for use by Vibe.d and others which embed this as subproject

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('stdx-allocator', 'd',
-    meson_version: '>=0.44',
+    meson_version: '>=0.45',
     license: 'BSL-1.0',
-    version: '2.77.0'
+    version: '2.77.1'
 )
 
 project_soversion = '0'

--- a/meson.build
+++ b/meson.build
@@ -52,7 +52,7 @@ allocator_lib = library('stdx-allocator',
 
 pkgc.generate(name: 'stdx-allocator',
               libraries: [allocator_lib],
-              subdirs: 'd/allocator',
+              subdirs: 'd/stdx',
               version: meson.project_version(),
               description: 'Extracted std.experimental.allocator for usage via DUB.'
 )


### PR DESCRIPTION
The things you notice in distro QA... With s `subdir` of `d/allocator`, projects will search for stdx.allocator in `/usr/include/d/allocator/`, which doesn't exist. The module is in `/usr/include/d/stdx/stdx/allocator` (double-stdx as always, because `/usr/include/d/` is in many D compiler's default include path which sometimes leads to the compiler including unwanted (system) copies of a module - which is a real nightmare in case the modules contain templates and you are debugging it and wonder why changes you make have no effect).
Therefore, the right subdir string is `d/stdx/`.

This PR also updates the project version number and sets a slightly more descriptive package summary for pkg-config.
(since a CI pass is required, I can't push the minor changes like a version update to master directly, unfortunately)