### PR TITLE
Remove dependency on deprecated std.c

### DIFF
--- a/source/stdx/allocator/building_blocks/allocator_list.d
+++ b/source/stdx/allocator/building_blocks/allocator_list.d
@@ -261,7 +261,7 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         }
         if (expanded)
         {
-            import std.c.string : memcpy;
+            import core.stdc.string : memcpy;
             assert(t.length % Node.sizeof == 0);
             assert(t.ptr.alignedAt(Node.alignof));
             allocators = cast(Node[]) t;

--- a/source/stdx/allocator/mallocator.d
+++ b/source/stdx/allocator/mallocator.d
@@ -133,7 +133,7 @@ version (Windows)
         @nogc nothrow
         private void* _aligned_malloc(size_t size, size_t alignment)
         {
-            import std.c.stdlib : malloc;
+            import core.stdc.stdlib : malloc;
             size_t offset = alignment + size_t.sizeof * 2 - 1;
 
             // unaligned chunk

--- a/source/stdx/allocator/mallocator.d
+++ b/source/stdx/allocator/mallocator.d
@@ -155,8 +155,8 @@ version (Windows)
         @nogc nothrow
         private void* _aligned_realloc(void* ptr, size_t size, size_t alignment)
         {
-            import std.c.stdlib : free;
-            import std.c.string : memcpy;
+            import core.stdc.stdlib : free;
+            import core.stdc.string : memcpy;
 
             if (!ptr) return _aligned_malloc(size, alignment);
 
@@ -182,7 +182,7 @@ version (Windows)
         @nogc nothrow
         private void _aligned_free(void *ptr)
         {
-            import std.c.stdlib : free;
+            import core.stdc.stdlib : free;
             if (!ptr) return;
             AlignInfo* head = AlignInfo(ptr);
             free(head.basePtr);


### PR DESCRIPTION
`std.c` is deprecated and the dependency is currently preventing https://github.com/dlang/phobos/pull/6515 from passing Circle CI.