### PR TITLE
Make gitignore ignore all static libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,10 @@ docs/
 allocator.so
 allocator.dylib
 allocator.dll
-allocator.a
 allocator.lib
 allocator-test-*
 stdx-allocator-test-*
+*.a
 *.exe
 *.o
 *.obj


### PR DESCRIPTION
When using this as path-based dub dependency, libstdx-allocator.a is generated