### PR TITLE
Mir & BetterC rework, stage 1

### DIFF
--- a/source/stdx/allocator/building_blocks/fallback_allocator.d
+++ b/source/stdx/allocator/building_blocks/fallback_allocator.d
@@ -43,7 +43,7 @@ struct FallbackAllocator(Primary, Fallback)
     */
     static if (!stateSize!Primary && !stateSize!Fallback)
     {
-        static FallbackAllocator instance;
+        enum FallbackAllocator instance = FallbackAllocator();
     }
 
     /**
@@ -125,7 +125,7 @@ struct FallbackAllocator(Primary, Fallback)
     static if (hasMember!(Primary, "owns"))
     bool reallocate(ref void[] b, size_t newSize)
     {
-        bool crossAllocatorMove(From, To)(ref From from, ref To to)
+        bool crossAllocatorMove(From, To)(auto ref From from, auto ref To to)
         {
             auto b1 = to.allocate(newSize);
             if (b1.length != newSize) return false;
@@ -153,7 +153,7 @@ struct FallbackAllocator(Primary, Fallback)
             || hasMember!(Fallback, "alignedAllocate")))
     bool alignedReallocate(ref void[] b, size_t newSize, uint a)
     {
-        bool crossAllocatorMove(From, To)(ref From from, ref To to)
+        bool crossAllocatorMove(From, To)(auto ref From from, auto ref To to)
         {
             static if (!hasMember!(To, "alignedAllocate"))
             {

--- a/source/stdx/allocator/building_blocks/null_allocator.d
+++ b/source/stdx/allocator/building_blocks/null_allocator.d
@@ -59,7 +59,7 @@ struct NullAllocator
     */
     static Ternary empty() { return Ternary.yes; }
     /**
-    static Returns the $(D static) global instance of the $(D NullAllocator).
+    Returns the $(D static) global instance of the $(D NullAllocator).
     */
     enum NullAllocator instance = NullAllocator();
 }

--- a/source/stdx/allocator/building_blocks/null_allocator.d
+++ b/source/stdx/allocator/building_blocks/null_allocator.d
@@ -20,48 +20,48 @@ struct NullAllocator
     //size_t goodAllocSize(size_t n) shared const
     //{ return .goodAllocSize(this, n); }
     /// Always returns $(D null).
-    void[] allocate(size_t) shared { return null; }
+    static void[] allocate(size_t) { return null; }
     /// Always returns $(D null).
-    void[] alignedAllocate(size_t, uint) shared { return null; }
+    static void[] alignedAllocate(size_t, uint) { return null; }
     /// Always returns $(D null).
-    void[] allocateAll() shared { return null; }
+    static void[] allocateAll() { return null; }
     /**
     These methods return $(D false).
     Precondition: $(D b is null). This is because there is no other possible
     legitimate input.
     */
-    bool expand(ref void[] b, size_t s) shared
+    static bool expand(ref void[] b, size_t s)
     { assert(b is null); return s == 0; }
     /// Ditto
-    bool reallocate(ref void[] b, size_t) shared
+    static bool reallocate(ref void[] b, size_t)
     { assert(b is null); return false; }
     /// Ditto
-    bool alignedReallocate(ref void[] b, size_t, uint) shared
+    static bool alignedReallocate(ref void[] b, size_t, uint)
     { assert(b is null); return false; }
     /// Returns $(D Ternary.no).
-    Ternary owns(void[]) shared const { return Ternary.no; }
+    static Ternary owns(void[]) { return Ternary.no; }
     /**
     Returns $(D Ternary.no).
     */
-    Ternary resolveInternalPointer(const void*, ref void[]) shared const
+    static Ternary resolveInternalPointer(const void*, ref void[])
     { return Ternary.no; }
     /**
     No-op.
     Precondition: $(D b is null)
     */
-    bool deallocate(void[] b) shared { assert(b is null); return true; }
+    static bool deallocate(void[] b) { assert(b is null); return true; }
     /**
     No-op.
     */
-    bool deallocateAll() shared { return true; }
+    static bool deallocateAll() { return true; }
     /**
     Returns $(D Ternary.yes).
     */
-    Ternary empty() shared const { return Ternary.yes; }
+    static Ternary empty() { return Ternary.yes; }
     /**
-    Returns the $(D shared) global instance of the $(D NullAllocator).
+    static Returns the $(D static) global instance of the $(D NullAllocator).
     */
-    static shared NullAllocator instance;
+    enum NullAllocator instance = NullAllocator();
 }
 
 @system unittest

--- a/source/stdx/allocator/building_blocks/quantizer.d
+++ b/source/stdx/allocator/building_blocks/quantizer.d
@@ -50,7 +50,7 @@ struct Quantizer(ParentAllocator, alias roundingFunction)
     else
     {
         alias parent = ParentAllocator.instance;
-        static __gshared Quantizer instance;
+        enum Quantizer instance = Quantizer();
     }
 
     /**

--- a/source/stdx/allocator/common.d
+++ b/source/stdx/allocator/common.d
@@ -347,7 +347,7 @@ defined. This is deliberate so allocators may use it internally within their own
 implementation of $(D reallocate).
 
 */
-bool reallocate(Allocator)(ref Allocator a, ref void[] b, size_t s)
+bool reallocate(Allocator)(auto ref Allocator a, ref void[] b, size_t s)
 {
     if (b.length == s) return true;
     static if (hasMember!(Allocator, "expand"))
@@ -378,7 +378,7 @@ defined. This is deliberate so allocators may use it internally within their own
 implementation of $(D reallocate).
 
 */
-bool alignedReallocate(Allocator)(ref Allocator alloc,
+bool alignedReallocate(Allocator)(auto ref Allocator alloc,
         ref void[] b, size_t s, uint a)
 {
     static if (hasMember!(Allocator, "expand"))

--- a/source/stdx/allocator/gc_allocator.d
+++ b/source/stdx/allocator/gc_allocator.d
@@ -22,7 +22,7 @@ struct GCAllocator
     deallocate) and $(D reallocate) methods are $(D @system) because they may
     move memory around, leaving dangling pointers in user code.
     */
-    pure nothrow @trusted void[] allocate(size_t bytes) shared
+    static pure nothrow @trusted void[] allocate(size_t bytes)
     {
         if (!bytes) return null;
         auto p = GC.malloc(bytes);
@@ -30,7 +30,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    @system bool expand(ref void[] b, size_t delta) shared
+    static @system bool expand(ref void[] b, size_t delta)
     {
         if (delta == 0) return true;
         if (b is null) return false;
@@ -53,7 +53,7 @@ struct GCAllocator
     }
 
     /// Ditto
-    pure nothrow @system bool reallocate(ref void[] b, size_t newSize) shared
+    static pure nothrow @system bool reallocate(ref void[] b, size_t newSize)
     {
         import core.exception : OutOfMemoryError;
         try
@@ -71,7 +71,7 @@ struct GCAllocator
 
     /// Ditto
     pure nothrow
-    Ternary resolveInternalPointer(const void* p, ref void[] result) shared
+    static Ternary resolveInternalPointer(const void* p, ref void[] result)
     {
         auto r = GC.addrOf(cast(void*) p);
         if (!r) return Ternary.no;
@@ -80,14 +80,14 @@ struct GCAllocator
     }
 
     /// Ditto
-    pure nothrow @system bool deallocate(void[] b) shared
+    static pure nothrow @system bool deallocate(void[] b)
     {
         GC.free(b.ptr);
         return true;
     }
 
     /// Ditto
-    size_t goodAllocSize(size_t n) shared
+    static size_t goodAllocSize(size_t n)
     {
         if (n == 0)
             return 0;
@@ -105,15 +105,14 @@ struct GCAllocator
     }
 
     /**
-    Returns the global instance of this allocator type. The garbage collected
-    allocator is thread-safe, therefore all of its methods and `instance` itself
-    are $(D shared).
+    Returns the global instance of this allocator type. The garbage collected allocator is
+    thread-safe, therefore all of its methods are $(D static) and `instance` itself is
+    $(D shared).
     */
-
-    static shared GCAllocator instance;
+    enum GCAllocator instance = GCAllocator();
 
     // Leave it undocummented for now.
-    nothrow @trusted void collect() shared
+    static nothrow @trusted void collect()
     {
         GC.collect();
     }

--- a/source/stdx/allocator/mallocator.d
+++ b/source/stdx/allocator/mallocator.d
@@ -23,7 +23,7 @@ struct Mallocator
     programs that can afford to leak memory allocated.
     */
     @trusted @nogc nothrow
-    void[] allocate(size_t bytes) shared
+    static void[] allocate(size_t bytes)
     {
         import core.stdc.stdlib : malloc;
         if (!bytes) return null;
@@ -33,7 +33,7 @@ struct Mallocator
 
     /// Ditto
     @system @nogc nothrow
-    bool deallocate(void[] b) shared
+    static bool deallocate(void[] b)
     {
         import core.stdc.stdlib : free;
         free(b.ptr);
@@ -42,7 +42,7 @@ struct Mallocator
 
     /// Ditto
     @system @nogc nothrow
-    bool reallocate(ref void[] b, size_t s) shared
+    static bool reallocate(ref void[] b, size_t s)
     {
         import core.stdc.stdlib : realloc;
         if (!s)
@@ -61,10 +61,10 @@ struct Mallocator
 
     /**
     Returns the global instance of this allocator type. The C heap allocator is
-    thread-safe, therefore all of its methods and `it` itself are
+    thread-safe, therefore all of its methods are $(D static) and `instance` itself is
     $(D shared).
     */
-    static shared Mallocator instance;
+    enum Mallocator instance = Mallocator();
 }
 
 ///
@@ -214,7 +214,7 @@ struct AlignedMallocator
     Forwards to $(D alignedAllocate(bytes, platformAlignment)).
     */
     @trusted @nogc nothrow
-    void[] allocate(size_t bytes) shared
+    static void[] allocate(size_t bytes)
     {
         if (!bytes) return null;
         return alignedAllocate(bytes, alignment);
@@ -228,7 +228,7 @@ struct AlignedMallocator
     */
     version(Posix)
     @trusted @nogc nothrow
-    void[] alignedAllocate(size_t bytes, uint a) shared
+    static void[] alignedAllocate(size_t bytes, uint a)
     {
         import core.stdc.errno : ENOMEM, EINVAL;
         assert(a.isGoodDynamicAlignment);
@@ -250,7 +250,7 @@ struct AlignedMallocator
     }
     else version(Windows)
     @trusted @nogc nothrow
-    void[] alignedAllocate(size_t bytes, uint a) shared
+    static void[] alignedAllocate(size_t bytes, uint a)
     {
         auto result = _aligned_malloc(bytes, a);
         return result ? result[0 .. bytes] : null;
@@ -264,7 +264,7 @@ struct AlignedMallocator
     */
     version (Posix)
     @system @nogc nothrow
-    bool deallocate(void[] b) shared
+    static bool deallocate(void[] b)
     {
         import core.stdc.stdlib : free;
         free(b.ptr);
@@ -272,7 +272,7 @@ struct AlignedMallocator
     }
     else version (Windows)
     @system @nogc nothrow
-    bool deallocate(void[] b) shared
+    static bool deallocate(void[] b)
     {
         _aligned_free(b.ptr);
         return true;
@@ -285,13 +285,13 @@ struct AlignedMallocator
     */
     version (Posix)
     @system @nogc nothrow
-    bool reallocate(ref void[] b, size_t newSize) shared
+    static bool reallocate(ref void[] b, size_t newSize)
     {
         return Mallocator.instance.reallocate(b, newSize);
     }
     version (Windows)
     @system @nogc nothrow
-    bool reallocate(ref void[] b, size_t newSize) shared
+    static bool reallocate(ref void[] b, size_t newSize)
     {
         return alignedReallocate(b, newSize, alignment);
     }
@@ -304,7 +304,7 @@ struct AlignedMallocator
     */
     version (Windows)
     @system @nogc nothrow
-    bool alignedReallocate(ref void[] b, size_t s, uint a) shared
+    static bool alignedReallocate(ref void[] b, size_t s, uint a)
     {
         if (!s)
         {
@@ -320,10 +320,10 @@ struct AlignedMallocator
 
     /**
     Returns the global instance of this allocator type. The C heap allocator is
-    thread-safe, therefore all of its methods and `instance` itself are
+    thread-safe, therefore all of its methods are $(D static) and `instance` itself is
     $(D shared).
     */
-    static shared AlignedMallocator instance;
+    enum AlignedMallocator instance = AlignedMallocator();
 }
 
 ///

--- a/source/stdx/allocator/mmap_allocator.d
+++ b/source/stdx/allocator/mmap_allocator.d
@@ -17,7 +17,7 @@ managed by fine-granular allocators.
 struct MmapAllocator
 {
     /// The one shared instance.
-    static shared MmapAllocator instance;
+    enum MmapAllocator instance = MmapAllocator();
 
     /**
     Alignment is page-size and hardcoded to 4096 (even though on certain systems
@@ -28,7 +28,7 @@ struct MmapAllocator
     version(Posix)
     {
         /// Allocator API.
-        void[] allocate(size_t bytes) shared
+        static void[] allocate(size_t bytes)
         {
             import core.sys.posix.sys.mman : mmap, MAP_ANON, PROT_READ,
                 PROT_WRITE, MAP_PRIVATE, MAP_FAILED;
@@ -40,7 +40,7 @@ struct MmapAllocator
         }
 
         /// Ditto
-        bool deallocate(void[] b) shared
+        static bool deallocate(void[] b)
         {
             import core.sys.posix.sys.mman : munmap;
             if (b.ptr) munmap(b.ptr, b.length) == 0 || assert(0);
@@ -53,7 +53,7 @@ struct MmapAllocator
             PAGE_READWRITE, MEM_RELEASE;
 
         /// Allocator API.
-        void[] allocate(size_t bytes) shared
+        static void[] allocate(size_t bytes)
         {
             if (!bytes) return null;
             auto p = VirtualAlloc(null, bytes, MEM_COMMIT, PAGE_READWRITE);
@@ -63,7 +63,7 @@ struct MmapAllocator
         }
 
         /// Ditto
-        bool deallocate(void[] b) shared
+        static bool deallocate(void[] b)
         {
             return b.ptr is null || VirtualFree(b.ptr, 0, MEM_RELEASE) != 0;
         }

--- a/source/stdx/allocator/package.d
+++ b/source/stdx/allocator/package.d
@@ -632,7 +632,7 @@ allocator can be cast to $(D shared).
     shared ISharedAllocator indirectShFLObj = sharedAllocatorObject(&sharedFL);
     testAllocatorObject(indirectShFLObj);
 
-    IAllocator indirectMallocator = allocatorObject(&Mallocator.instance);
+    IAllocator indirectMallocator = allocatorObject(Mallocator.instance);
     testAllocatorObject(indirectMallocator);
 }
 

--- a/source/stdx/allocator/typed.d
+++ b/source/stdx/allocator/typed.d
@@ -403,11 +403,11 @@ struct TypedAllocator(PrimaryAllocator, Policies...)
             MmapAllocator,
     );
     MyAllocator a;
-    auto b = &a.allocatorFor!0();
-    static assert(is(typeof(*b) == shared GCAllocator));
+    auto b = a.allocatorFor!0();
+    static assert(is(typeof(b) == GCAllocator));
     enum f1 = AllocFlag.fixedSize | AllocFlag.threadLocal;
-    auto c = &a.allocatorFor!f1();
-    static assert(is(typeof(*c) == Mallocator));
+    auto c = a.allocatorFor!f1();
+    static assert(is(typeof(c) == Mallocator));
     enum f2 = AllocFlag.fixedSize | AllocFlag.threadLocal;
     static assert(is(typeof(a.allocatorFor!f2()) == Mallocator));
     // Partial match


### PR DESCRIPTION
First step, remove `instance` as object member. It is `enum` now. 

Next PR: convert all methods of basic allocatros to templates.

This will require a major release.