### PR TITLE
Only test the master and stable branch to avoid double CI executions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ d:
 env:
  - ARCH="x86_64"
 
+branches:
+  only:
+  - master
+  - stable
+
 matrix:
   include:
     - {os: linux, d: ldc-beta, env: ARCH="x86", addons: {apt: {packages: [[gcc-multilib]]}}}


### PR DESCRIPTION
> By the way i see that you pushed your branch to the origin but it's better to make PR with your fork because otherwise there are two CI tests (push and PR), which means computing resource wasting.
> Afaik there's no way to avoid that in the settings.

This should do the trick.