### PR TITLE
Partial support for WebAssembly

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -4,3 +4,10 @@ authors "Team Phobos"
 copyright "Copyright © 2017, Team Phobos"
 license "BSL-1.0"
 dependency "mir-core" version=">=0.0.5 <0.3.0"
+
+configuration "unittest" {
+}
+
+configuration "wasm" {
+	dflags "-mtriple=wasm32-unknown-unknown-wasm" "-betterC"
+}

--- a/source/stdx/allocator/building_blocks/region.d
+++ b/source/stdx/allocator/building_blocks/region.d
@@ -390,6 +390,7 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     else version (MIPS64) enum growDownwards = Yes.growDownwards;
     else version (SPARC) enum growDownwards = Yes.growDownwards;
     else version (SystemZ) enum growDownwards = Yes.growDownwards;
+    else version (WebAssembly) enum growDownwards = Yes.growDownwards;
     else static assert(0, "Dunno how the stack grows on this architecture.");
 
     @disable this(this);

--- a/source/stdx/allocator/building_blocks/segregator.d
+++ b/source/stdx/allocator/building_blocks/segregator.d
@@ -247,7 +247,7 @@ struct Segregator(size_t threshold, SmallAllocator, LargeAllocator)
                 && __traits(hasMember, LargeAllocator, "empty"))
         Ternary empty()
         {
-            return _small.empty && _large.empty;
+            return _small.empty & _large.empty;
         }
 
         static if (__traits(hasMember, SmallAllocator, "resolveInternalPointer")

--- a/source/stdx/allocator/building_blocks/stats_collector.d
+++ b/source/stdx/allocator/building_blocks/stats_collector.d
@@ -160,7 +160,7 @@ struct StatsCollector(Allocator, ulong flags = Options.all,
 private:
     import stdx.allocator.internal : Ternary;
 
-    static string define(string type, string[] names...)
+    enum define = (string type, string[] names...)
     {
         string result;
         foreach (v; names)
@@ -169,7 +169,7 @@ private:
                 ~ "public const("~type~") "~v~"() const { return _"~v~"; }"
                 ~ "}";
         return result;
-    }
+    };
 
     void add(string counter)(sizediff_t n)
     {

--- a/source/stdx/allocator/common.d
+++ b/source/stdx/allocator/common.d
@@ -403,7 +403,7 @@ bool alignedReallocate(Allocator)(auto ref Allocator alloc,
 /**
 Forwards each of the methods in `funs` (if defined) to `member`.
 */
-/*package*/ string forwardToMember(string member, string[] funs...)
+/*package*/ enum forwardToMember = (string member, string[] funs...)
 {
     string result = "    import std.traits : Parameters;\n";
     foreach (fun; funs)
@@ -424,7 +424,7 @@ Forwards each of the methods in `funs` (if defined) to `member`.
     }\n";
     }
     return result;
-}
+};
 
 version(unittest)
 {

--- a/source/stdx/allocator/gc_allocator.d
+++ b/source/stdx/allocator/gc_allocator.d
@@ -2,6 +2,14 @@
 module stdx.allocator.gc_allocator;
 import stdx.allocator.common;
 
+version (D_BetterC) {
+    import stdx.allocator.building_blocks.null_allocator;
+    alias GCAllocator = NullAllocator;
+} else
+    version = HasDRuntime;
+
+version (HasDRuntime):
+
 /**
 D's built-in garbage-collected allocator.
  */

--- a/source/stdx/allocator/mallocator.d
+++ b/source/stdx/allocator/mallocator.d
@@ -201,6 +201,9 @@ version (Windows)
 /**
    Aligned allocator using OS-specific primitives, under a uniform API.
  */
+version (WebAssembly) {} else version = HasMemAlign;
+
+version (HasMemAlign)
 struct AlignedMallocator
 {
     @system unittest { testAllocator!(() => typeof(this).instance); }

--- a/source/stdx/allocator/package.d
+++ b/source/stdx/allocator/package.d
@@ -223,6 +223,10 @@ Source: $(PHOBOSSRC std/experimental/_allocator)
 
 module stdx.allocator;
 
+version (D_BetterC) {} else version = HasDRuntime;
+
+version (HasDRuntime):
+
 public import stdx.allocator.common,
     stdx.allocator.typed;
 

--- a/source/stdx/allocator/showcase.d
+++ b/source/stdx/allocator/showcase.d
@@ -7,6 +7,10 @@ facilities, or import individual heap building blocks and assemble them.
 */
 module stdx.allocator.showcase;
 
+version (D_BetterC) {} else version = HasDRuntime;
+
+version (HasDRuntime):
+
 import stdx.allocator.building_blocks.fallback_allocator,
     stdx.allocator.gc_allocator,
     stdx.allocator.building_blocks.region;


### PR DESCRIPTION
These are the [WIP] changes I need, so that I can use more of stdx.allocator in WebAssembly.

I have only used the BitmappedBlock, FreeTree, Segregator and the AllocationList so far. Other allocators may still fail.

I would like to know if the proposed changes are ok.

- added a configuration to compile the library for wasm (otherwise dub would just compile to a host object file)
- fixed the testAllocator for BitmappedBlock when choosing blockSize at runtime
- fixed the assert in blockSize property in BitmappedBlocks
- I backported the chooseAtRuntime constructor for BitmappedBlocks
- fixed the Ternary empty() in BitmappedBlocks (logical and is not defined on Ternary. For good reasons)
- used the enum lambda trick to support forwardToMember in common in CTFE in betterC
- used the enum lambda trick to support define in stats_collector in CTFE in betterC
- alias GCAllocator to NullAllocator in betterC (some allocators use GCAllocator as a default template parameter pulling in the druntime)
- version out the AlignedAllocator
- version out the package.d
- version out the showcase.d