### PR TITLE
wasm needs targettype to be sourceLibrary

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -10,4 +10,5 @@ configuration "unittest" {
 
 configuration "wasm" {
 	dflags "-mtriple=wasm32-unknown-unknown-wasm" "-betterC"
+	targetType "sourceLibrary"
 }


### PR DESCRIPTION
Otherwise lld won't link it correctly with the dependant. For templates it is not an issue, but for regular functions it is.