### PR TITLE
Fix AllocatorList not compiling for allocators that don't define 'owns'

### DIFF
--- a/source/stdx/allocator/building_blocks/allocator_list.d
+++ b/source/stdx/allocator/building_blocks/allocator_list.d
@@ -643,9 +643,9 @@ version(Posix) @system unittest
 unittest
 {
 	import stdx.allocator.building_blocks.free_list;
-	alias OwnlessAllocator = GCAllocator;
+	alias OwnlessAllocator = ContiguousFreeList!(GCAllocator, size_t.sizeof);
 	static assert(!__traits(hasMember, OwnlessAllocator, "owns"), 
 	    "This test requires an ownless allocator."
 	);
-	alias A = AllocatorList!(_ => ContiguousFreeList!(GCAllocator, size_t.sizeof)(1));
+	alias A = AllocatorList!(_ => OwnlessAllocator(1));
 }

--- a/source/stdx/allocator/building_blocks/allocator_list.d
+++ b/source/stdx/allocator/building_blocks/allocator_list.d
@@ -187,8 +187,8 @@ struct AllocatorList(Factory, BookkeepingAllocator = GCAllocator)
         if (auto a = addAllocator(s))
         {
             auto result = a.allocate(s);
-			static if (__traits(hasMember, Allocator, "owns"))
-				assert(owns(result) == Ternary.yes || !result.ptr);
+            static if (__traits(hasMember, Allocator, "owns"))
+                assert(owns(result) == Ternary.yes || !result.ptr);
             return result;
         }
         return null;
@@ -645,7 +645,7 @@ unittest
 	import stdx.allocator.building_blocks.free_list;
 	alias OwnlessAllocator = GCAllocator;
 	static assert(!__traits(hasMember, OwnlessAllocator, "owns"), 
-		"This test requires an ownless allocator."
+	    "This test requires an ownless allocator."
 	);
 	alias A = AllocatorList!(_ => ContiguousFreeList!(GCAllocator, size_t.sizeof)(1));
 }


### PR DESCRIPTION
Found out as `GCAllocator` doesn't define `owns`.