### PR TITLE
Add support for LoongArch64

### DIFF
--- a/source/stdx/allocator/building_blocks/region.d
+++ b/source/stdx/allocator/building_blocks/region.d
@@ -391,6 +391,7 @@ struct InSituRegion(size_t size, size_t minAlign = platformAlignment)
     else version (SPARC) enum growDownwards = Yes.growDownwards;
     else version (SystemZ) enum growDownwards = Yes.growDownwards;
     else version (WebAssembly) enum growDownwards = Yes.growDownwards;
+    else version (LoongArch64) enum growDownwards = Yes.growDownwards;
     else static assert(0, "Dunno how the stack grows on this architecture.");
 
     @disable this(this);


### PR DESCRIPTION
LoongArch is a new RISC ISA developed by loongson, which is a bit like MIPS or RISC-V.There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it.
I've added definition in region.d to support LoongArch64
I've tested my patch for LoongArch64's archlinux port:Success[view the log](https://gist.github.com/RealRoller233/e3699c36d6b46fbd18d2fe708bf1d8e7)
